### PR TITLE
feat: update to nextversion 0.5.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,3 +19,4 @@ jobs:
           echo "HasNext: ${{ steps.version.outputs.hasNextVersion }}"
           echo "Prerelease: ${{ steps.version.outputs.prereleaseVersion }}"
           echo "PrereleaseStrict: ${{ steps.version.outputs.prereleaseVersionStrict }}"
+          echo "PrereleaseDockerTag: ${{ steps.version.outputs.prereleaseDockerTag }}"

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ nextversion-action uses [nextversion](https://github.com/tsdtsdtsd/nextversion) 
 | `nextVersionStrict` | same as `nextVersion`, but without the `v` prefix | `1.3.0` |
 | `prereleaseVersion` | calculated prerelease version | `v1.3.0-rc+dev.4fa53ce` |
 | `prereleaseVersionStrict` | same as `prereleaseVersion`, but without the `v` prefix | `1.3.0-rc+dev.4fa53ce` |
+| `prereleaseDockerTag` | same as `prereleaseVersionStrict`, but sanitized for use as a docker tag | `1.3.0-rc-dev.4fa53ce` |
 
 ## Usage Example
 
@@ -66,14 +67,15 @@ jobs:
 
     - name: Debug nextversion output
       run: |
-        echo 'hasCurrentVersion: ${{ steps.nextversion.outputs.hasCurrentVersion }}'
-        echo 'hasNextVersion:    ${{ steps.nextversion.outputs.hasNextVersion }}'
-        echo 'current:           ${{ steps.nextversion.outputs.currentVersion }}'
-        echo 'current strict:    ${{ steps.nextversion.outputs.currentVersionStrict }}'
-        echo 'next:              ${{ steps.nextversion.outputs.nextVersion }}'
-        echo 'next strict:       ${{ steps.nextversion.outputs.nextVersionStrict }}'
-        echo 'prestable:         ${{ steps.nextversion.outputs.prestableVersion }}'
-        echo 'prestable strict:  ${{ steps.nextversion.outputs.prestableVersionStrict }}'
+        echo 'hasCurrentVersion:      ${{ steps.nextversion.outputs.hasCurrentVersion }}'
+        echo 'hasNextVersion:         ${{ steps.nextversion.outputs.hasNextVersion }}'
+        echo 'current:                ${{ steps.nextversion.outputs.currentVersion }}'
+        echo 'current strict:         ${{ steps.nextversion.outputs.currentVersionStrict }}'
+        echo 'next:                   ${{ steps.nextversion.outputs.nextVersion }}'
+        echo 'next strict:            ${{ steps.nextversion.outputs.nextVersionStrict }}'
+        echo 'prerelease:             ${{ steps.nextversion.outputs.prereleaseVersion }}'
+        echo 'prerelease strict:      ${{ steps.nextversion.outputs.prereleaseVersionStrict }}'
+        echo 'prerelease docker tag:  ${{ steps.nextversion.outputs.prereleaseDockerTag }}'
 ```
 
 ### Prestable Mode

--- a/action.yml
+++ b/action.yml
@@ -43,6 +43,9 @@ outputs:
   prereleaseVersionStrict:
     description: "Bumped prerelease version based on tags, always without a prefix"
     value: "${{ steps.version.outputs.prereleaseVersionStrict }}"
+  prereleaseDockerTag:
+    description: "Bumped prerelease version based on tags, always without a prefix"
+    value: "${{ steps.version.outputs.prereleaseDockerTag }}"
 
 runs:
   using: "composite"
@@ -58,7 +61,7 @@ runs:
         #   download_url="https://github.com/tsdtsdtsd/nextversion/releases/download/${{ inputs.tool-version }}/nextversion_Linux_x86_64.tar.gz"
         # fi
 
-        download_url="https://github.com/tsdtsdtsd/nextversion/releases/download/v0.4.1/nextversion_Linux_x86_64.tar.gz"
+        download_url="https://github.com/tsdtsdtsd/nextversion/releases/download/v0.5.1/nextversion_Linux_x86_64.tar.gz"
 
         curl -L "$download_url" > /tmp/nextversion.tar.gz
         tar -xzvf /tmp/nextversion.tar.gz -C /tmp
@@ -90,4 +93,4 @@ runs:
         echo "hasNextVersion=$(echo $versionJSON | jq -r '."has-next"')" >> $GITHUB_OUTPUT
         echo "prereleaseVersion=$(echo $versionJSON | jq -r '."prerelease"')" >> $GITHUB_OUTPUT
         echo "prereleaseVersionStrict=$(echo $versionJSON | jq -r '."prerelease-strict"')" >> $GITHUB_OUTPUT
-        
+        echo "prereleaseDockerTag=$(echo $versionJSON | jq -r '."prerelease-docker-tag"')" >> $GITHUB_OUTPUT


### PR DESCRIPTION
This update introduces the `prereleaseDockerTag` output, a sanitized prerelease version output for use as a docker tag.

Closes #4 